### PR TITLE
Add ML skeleton with notebooks and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# kickoff
+# Handwritten Digit Classification Project
+
+This repository contains a simple example of classifying handwritten digits using the MNIST dataset.
+
+## Structure
+
+- `theoretical_questions.md` – placeholder for theoretical answers extracted from the PDF.
+- `notebooks/01_exploration.ipynb` – notebook for exploring the data.
+- `notebooks/02_modeling.ipynb` – notebook for training a model.
+- `train.py` – script to train a convolutional neural network and save it as `model.h5`.
+- `predict.py` – script that loads the trained model and predicts the digit of an image provided on the command line.
+- `app.py` – a small Flask web interface to upload an image and see the predicted digit.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Train the model:
+   ```bash
+   python train.py
+   ```
+3. Predict a digit from an image:
+   ```bash
+   python predict.py path/to/image.png
+   ```
+4. Launch the web application:
+   ```bash
+   python app.py
+   ```
+
+## Results
+
+Running `train.py` will train a small CNN for five epochs on MNIST. Accuracy will depend on the runtime environment.
+
+## Conclusion
+
+This project demonstrates a minimal pipeline for loading data, training a model, making predictions via script and web interface, and presenting results.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,36 @@
+from flask import Flask, request, render_template_string
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing import image
+import numpy as np
+import io
+
+app = Flask(__name__)
+model = load_model('model.h5')
+
+HTML = """
+<!doctype html>
+<title>Digit Classifier</title>
+<h1>Upload an image</h1>
+<form method=post enctype=multipart/form-data>
+  <input type=file name=file>
+  <input type=submit value=Upload>
+</form>
+{% if pred is not none %}
+<p>Predicted digit: {{ pred }}</p>
+{% endif %}
+"""
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    pred = None
+    if request.method == 'POST':
+        f = request.files['file']
+        if f:
+            img = image.load_img(io.BytesIO(f.read()), target_size=(28,28), color_mode='grayscale')
+            img_array = image.img_to_array(img).reshape(1,28,28,1) / 255.0
+            out = model.predict(img_array)
+            pred = int(np.argmax(out))
+    return render_template_string(HTML, pred=pred)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/notebooks/01_exploration.ipynb
+++ b/notebooks/01_exploration.ipynb
@@ -1,0 +1,1 @@
+{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Exploration\n", "\n", "This notebook explores the MNIST dataset."]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python"}}, "nbformat": 4, "nbformat_minor": 2}

--- a/notebooks/02_modeling.ipynb
+++ b/notebooks/02_modeling.ipynb
@@ -1,0 +1,1 @@
+{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# Modeling\n", "\n", "This notebook trains a simple model."]}], "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python"}}, "nbformat": 4, "nbformat_minor": 2}

--- a/pdf_content.md
+++ b/pdf_content.md
@@ -1,0 +1,5 @@
+# PDF Content
+
+*La conversion automatique du fichier PDF n'a pas été possible dans cet environnement.*
+
+Veuillez vous référer au document original `Handwritten Digits Classification (1).pdf` pour le contenu complet.

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,14 @@
+import sys
+import numpy as np
+from tensorflow.keras.models import load_model
+from tensorflow.keras.preprocessing import image
+
+model = load_model('model.h5')
+
+img_path = sys.argv[1]
+img = image.load_img(img_path, target_size=(28,28), color_mode='grayscale')
+img_array = image.img_to_array(img)
+img_array = img_array.reshape(1,28,28,1) / 255.0
+
+pred = model.predict(img_array)
+print('Predicted digit:', np.argmax(pred))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tensorflow
+flask

--- a/theoretical_questions.md
+++ b/theoretical_questions.md
@@ -1,0 +1,8 @@
+# Questions Théoriques
+
+*Remarque : le contenu du PDF n'a pas pu être extrait automatiquement dans cet environnement.*
+
+1. **Question 1** : _En attente de la question exacte._
+2. **Question 2** : _En attente de la question exacte._
+
+Ces réponses seront complétées ultérieurement.

--- a/train.py
+++ b/train.py
@@ -1,0 +1,28 @@
+import tensorflow as tf
+from tensorflow.keras.datasets import mnist
+from tensorflow.keras.utils import to_categorical
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Conv2D, MaxPooling2D, Flatten, Dense
+
+# Load data
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+x_train = x_train.reshape(-1, 28, 28, 1).astype('float32') / 255
+x_test = x_test.reshape(-1, 28, 28, 1).astype('float32') / 255
+
+# One-hot encode labels
+y_train = to_categorical(y_train, 10)
+y_test = to_categorical(y_test, 10)
+
+# Build simple CNN
+model = Sequential([
+    Conv2D(32, (3,3), activation='relu', input_shape=(28,28,1)),
+    MaxPooling2D((2,2)),
+    Flatten(),
+    Dense(100, activation='relu'),
+    Dense(10, activation='softmax')
+])
+
+model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
+
+model.fit(x_train, y_train, epochs=5, validation_data=(x_test, y_test))
+model.save('model.h5')


### PR DESCRIPTION
## Summary
- add placeholder extraction for PDF
- answer space for theoretical questions
- add basic notebooks
- implement simple CNN train/predict scripts and Flask app
- update README with instructions

## Testing
- `python -m py_compile train.py predict.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6842d0b86920832f932017024e84c4d7